### PR TITLE
Expose sampler listing helpers in training scripts

### DIFF
--- a/04_training/batch_samplers.py
+++ b/04_training/batch_samplers.py
@@ -1,0 +1,204 @@
+"""Batch sampling utilities for training runs.
+
+Provides a registry-driven interface so training scripts can
+switch between the stock uniform sampler and experimental
+alternatives (e.g. a variance-aware sampler) through
+configuration alone. The variance-aware sampler implemented
+here is a lightweight approximation that oversamples high
+variance windows – it is intended to be a drop-in scaffold
+that you can evolve into a full PBit implementation without
+having to touch the trainers again.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SamplerSpec:
+    """Simple spec used by :func:`build_batch_sampler`."""
+
+    name: str
+    kwargs: Dict[str, object]
+
+
+class BaseBatchSampler:
+    """Abstract base class for batch samplers."""
+
+    def sample(
+        self,
+        data: np.memmap,
+        block_size: int,
+        batch_size: int,
+        *,
+        generator: Optional[torch.Generator] = None,
+    ) -> torch.Tensor:
+        """Return the starting offsets for ``batch_size`` sequences."""
+
+        raise NotImplementedError
+
+
+class UniformBatchSampler(BaseBatchSampler):
+    """Replicates the original ``torch.randint`` sampling logic."""
+
+    def sample(
+        self,
+        data: np.memmap,
+        block_size: int,
+        batch_size: int,
+        *,
+        generator: Optional[torch.Generator] = None,
+    ) -> torch.Tensor:
+        upper = max(1, len(data) - block_size)
+        if generator is None:
+            return torch.randint(upper, (batch_size,))
+        return torch.randint(upper, (batch_size,), generator=generator)
+
+
+class PBitVarianceAwareSampler(BaseBatchSampler):
+    """Simple variance-aware sampler scaffolding.
+
+    The sampler oversamples candidate windows with high token
+    variance to approximate a PBit-style variance-aware
+    strategy. It draws a pool of candidate offsets uniformly,
+    scores them by variance, and then samples without
+    replacement weighted by those scores.
+    """
+
+    def __init__(
+        self,
+        oversample_factor: int = 4,
+        min_candidate_windows: int = 64,
+        temperature: float = 1.0,
+        epsilon: float = 1e-8,
+    ) -> None:
+        if oversample_factor < 1:
+            raise ValueError("oversample_factor must be >= 1")
+        self.oversample_factor = oversample_factor
+        self.min_candidate_windows = min_candidate_windows
+        self.temperature = max(temperature, 1e-6)
+        self.epsilon = epsilon
+        logger.debug(
+            "Initialised variance-aware sampler with oversample_factor=%s, min_candidate_windows=%s",
+            oversample_factor,
+            min_candidate_windows,
+        )
+
+    def _select_candidate_offsets(
+        self,
+        total_windows: int,
+        batch_size: int,
+        *,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        num_candidates = min(
+            total_windows,
+            max(batch_size * self.oversample_factor, self.min_candidate_windows),
+        )
+        if generator is None:
+            return torch.randint(total_windows, (num_candidates,))
+        return torch.randint(total_windows, (num_candidates,), generator=generator)
+
+    def _score_windows(
+        self,
+        data: np.memmap,
+        block_size: int,
+        offsets: Iterable[int],
+    ) -> torch.Tensor:
+        scores = []
+        for offset in offsets:
+            window = np.asarray(data[offset : offset + block_size], dtype=np.float32)
+            if window.size == 0:
+                scores.append(0.0)
+                continue
+            variance = float(window.var())
+            scores.append(variance)
+        return torch.tensor(scores, dtype=torch.float32)
+
+    def sample(
+        self,
+        data: np.memmap,
+        block_size: int,
+        batch_size: int,
+        *,
+        generator: Optional[torch.Generator] = None,
+    ) -> torch.Tensor:
+        total_windows = max(1, len(data) - block_size)
+        candidates = self._select_candidate_offsets(
+            total_windows, batch_size, generator=generator
+        )
+        scores = self._score_windows(data, block_size, candidates.tolist())
+        # Stabilise and normalise scores into sampling weights
+        adjusted_scores = (scores + self.epsilon) / self.temperature
+        weights = torch.softmax(adjusted_scores, dim=0)
+        num_samples = min(batch_size, candidates.numel())
+        # ``torch.multinomial`` requires CPU tensors
+        cpu_weights = weights.cpu()
+        cpu_candidates = candidates.cpu()
+        if generator is None:
+            selection = torch.multinomial(cpu_weights, num_samples, replacement=False)
+        else:
+            selection = torch.multinomial(
+                cpu_weights, num_samples, replacement=False, generator=generator
+            )
+        chosen = cpu_candidates[selection]
+        if chosen.numel() < batch_size:
+            fallback = UniformBatchSampler().sample(
+                data, block_size, batch_size - chosen.numel(), generator=generator
+            )
+            chosen = torch.cat([chosen, fallback.cpu()])
+        return chosen.to(torch.long)
+
+
+SAMPLER_REGISTRY: Dict[str, type[BaseBatchSampler]] = {
+    "uniform": UniformBatchSampler,
+    "variance_aware": PBitVarianceAwareSampler,
+    "pbit": PBitVarianceAwareSampler,
+}
+
+
+def build_batch_sampler(name: Optional[str], **kwargs: object) -> BaseBatchSampler:
+    """Instantiate a batch sampler by name.
+
+    Parameters
+    ----------
+    name:
+        Registry key for the sampler. Defaults to ``"uniform"`` when
+        ``None`` is provided so existing runs stay identical.
+    kwargs:
+        Keyword arguments forwarded to the sampler constructor.
+    """
+
+    if not name:
+        name = "uniform"
+    key = name.lower()
+    if key not in SAMPLER_REGISTRY:
+        raise ValueError(
+            f"Unknown sampler '{name}'. Available options: {sorted(SAMPLER_REGISTRY)}"
+        )
+    sampler_cls = SAMPLER_REGISTRY[key]
+    return sampler_cls(**kwargs)
+
+
+def get_available_sampler_names() -> List[str]:
+    """Return the sorted list of registered sampler names."""
+
+    return sorted(SAMPLER_REGISTRY.keys())
+
+
+__all__ = [
+    "BaseBatchSampler",
+    "UniformBatchSampler",
+    "PBitVarianceAwareSampler",
+    "SamplerSpec",
+    "build_batch_sampler",
+    "SAMPLER_REGISTRY",
+    "get_available_sampler_names",
+]

--- a/04_training/train_model.py
+++ b/04_training/train_model.py
@@ -21,11 +21,14 @@ from typing import Dict, Any, Optional
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # Add project root to path
-project_root = Path(__file__).parent.parent
+training_dir = Path(__file__).parent
+project_root = training_dir.parent
 sys.path.append(str(project_root))
+sys.path.append(str(training_dir))
 
-# Import global configuration
+# Import global configuration and sampler utilities
 from config import config
+from batch_samplers import build_batch_sampler, get_available_sampler_names
 
 try:
     import torch
@@ -241,8 +244,16 @@ class MLP(torch.nn.Module):
 
 class LondonHistoricalTrainer:
     """Modern trainer based on nanoGPT approach - Regular model"""
-    
-    def __init__(self, data_dir: str, tokenizer_dir: str, output_dir: str, resume_from_checkpoint: str = None):
+
+    def __init__(
+        self,
+        data_dir: str,
+        tokenizer_dir: str,
+        output_dir: str,
+        resume_from_checkpoint: str = None,
+        sampler_type: Optional[str] = None,
+        sampler_kwargs: Optional[Dict[str, Any]] = None,
+    ):
         self.data_dir = Path(data_dir)
         self.tokenizer_dir = Path(tokenizer_dir)
         self.output_dir = Path(output_dir)
@@ -271,7 +282,23 @@ class LondonHistoricalTrainer:
         self.n_embd = self.training_config.get("n_embd", 1024)
         self.dropout = 0.1
         self.bias = False
-        
+
+        sampler_cfg = self.training_config.get("sampler", {})
+        default_sampler_type = sampler_cfg.get(
+            "type", self.training_config.get("sampler_type", "uniform")
+        )
+        default_sampler_kwargs = sampler_cfg.get(
+            "kwargs", self.training_config.get("sampler_kwargs", {})
+        )
+        if sampler_type is not None:
+            default_sampler_type = sampler_type
+        if sampler_kwargs:
+            merged_kwargs = {**default_sampler_kwargs, **sampler_kwargs}
+        else:
+            merged_kwargs = dict(default_sampler_kwargs)
+        self.sampler_type = default_sampler_type
+        self.sampler_kwargs = merged_kwargs
+
         # System
         self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
         # Precision / TF32 knobs from config
@@ -307,7 +334,16 @@ class LondonHistoricalTrainer:
             self.master_process = True
             self.seed_offset = 0
             self.ddp_world_size = 1
-        
+
+        self.batch_generator = torch.Generator(device='cpu')
+        self.batch_generator.manual_seed(1337 + self.seed_offset)
+        self.batch_sampler = build_batch_sampler(self.sampler_type, **self.sampler_kwargs)
+        logger.info(
+            "Using batch sampler '%s' with kwargs=%s",
+            self.sampler_type,
+            self.sampler_kwargs,
+        )
+
         # WandB setup
         self.use_wandb = self.training_config.get("use_wandb", False) and self.master_process
         if self.use_wandb:
@@ -444,10 +480,20 @@ class LondonHistoricalTrainer:
         # Load data
         data = np.memmap(data_file, dtype=np.uint16, mode='r')
         
-        # Sample random sequences
-        ix = torch.randint(len(data) - self.block_size, (self.batch_size,))
-        x = torch.stack([torch.from_numpy((data[i:i+self.block_size]).astype(np.int64)) for i in ix])
-        y = torch.stack([torch.from_numpy((data[i+1:i+1+self.block_size]).astype(np.int64)) for i in ix])
+        # Sample sequences through the configured sampler
+        indices = self.batch_sampler.sample(
+            data, self.block_size, self.batch_size, generator=self.batch_generator
+        )
+        ix = indices.to(torch.long)
+        x = torch.stack(
+            [torch.from_numpy((data[i : i + self.block_size]).astype(np.int64)) for i in ix]
+        )
+        y = torch.stack(
+            [
+                torch.from_numpy((data[i + 1 : i + 1 + self.block_size]).astype(np.int64))
+                for i in ix
+            ]
+        )
         
         if self.device == 'cuda':
             x, y = x.pin_memory().to(self.device, non_blocking=True), y.pin_memory().to(self.device, non_blocking=True)
@@ -780,8 +826,35 @@ def main():
                        help="Directory to save trained model")
     parser.add_argument("--resume_from_checkpoint", type=str, default=None,
                        help="Path to checkpoint file to resume from")
-    
+    parser.add_argument(
+        "--sampler_type",
+        type=str,
+        default=None,
+        choices=get_available_sampler_names(),
+        help="Override the sampler defined in the config",
+    )
+    parser.add_argument(
+        "--sampler_kwargs",
+        type=str,
+        default=None,
+        help=(
+            "JSON string or path to a JSON file with keyword arguments for the "
+            "selected sampler"
+        ),
+    )
+    parser.add_argument(
+        "--list_samplers",
+        action="store_true",
+        help="List the registered samplers and exit",
+    )
+
     args = parser.parse_args()
+
+    if args.list_samplers:
+        print("Available samplers:")
+        for name in get_available_sampler_names():
+            print(f" - {name}")
+        return
     
     # DDP setup
     ddp = int(os.environ.get('RANK', -1)) != -1
@@ -803,11 +876,27 @@ def main():
     torch.manual_seed(1337 + seed_offset)
     
     # Create trainer
+    sampler_kwargs = None
+    if args.sampler_kwargs:
+        potential_path = Path(args.sampler_kwargs)
+        try:
+            if potential_path.exists():
+                with open(potential_path, 'r', encoding='utf-8') as fh:
+                    sampler_kwargs = json.load(fh)
+            else:
+                sampler_kwargs = json.loads(args.sampler_kwargs)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "Failed to parse --sampler_kwargs; provide a JSON string or path to a JSON file"
+            ) from exc
+
     trainer = LondonHistoricalTrainer(
         data_dir=args.data_dir,
         tokenizer_dir=args.tokenizer_dir,
         output_dir=args.output_dir,
-        resume_from_checkpoint=args.resume_from_checkpoint
+        resume_from_checkpoint=args.resume_from_checkpoint,
+        sampler_type=args.sampler_type,
+        sampler_kwargs=sampler_kwargs,
     )
     
     # Start training

--- a/08_documentation/TRAINING_GUIDE.md
+++ b/08_documentation/TRAINING_GUIDE.md
@@ -294,6 +294,41 @@ cd 04_training
 python train_model.py
 ```
 
+### **Switching Between Samplers for A/B Runs**
+
+Both training scripts now accept a sampler override so you can reproduce the
+baseline run and your variance-aware experiments without editing code:
+
+- **Configuration default** – the project keeps using the original uniform sampler
+  unless you change `sampler.type` in `config.py`.
+- **CLI override** – pass `--sampler_type variance_aware` when you want to swap in
+  the variance-aware logic for either trainer.
+- **Discover available samplers** – run `python train_model_slm.py --list_samplers`
+  (or use the regular trainer) to print the registry defined in
+  `04_training/batch_samplers.py`. This makes it easy to confirm your branch is in
+  sync with the current `main` before launching experiments.
+- **Sampler kwargs** – provide additional tuning options as JSON:
+  `--sampler_kwargs '{"oversample_factor": 8, "temperature": 0.5}'` or point to a
+  JSON file.
+
+Example commands:
+
+```bash
+# Baseline SLM run (uniform sampling)
+torchrun --nproc_per_node=2 train_model_slm.py --sampler_type uniform
+
+# Variance-aware SLM run with custom oversampling factor
+torchrun --nproc_per_node=2 train_model_slm.py \
+  --sampler_type variance_aware \
+  --sampler_kwargs '{"oversample_factor": 6, "min_candidate_windows": 256}'
+
+# Regular model variance-aware run
+torchrun --nproc_per_node=2 train_model.py --sampler_type variance_aware
+```
+
+The trainers log the active sampler and kwargs at startup, making it easy to
+verify which strategy produced a given checkpoint or WandB run.
+
 ### **Automatic GPU Detection (Recommended):**
 ```bash
 cd 04_training

--- a/config.py
+++ b/config.py
@@ -97,7 +97,15 @@ class Config:
             "enable_tf32": True,
             "enable_amp": True,
             "amp_dtype": "bf16",
-            "enable_compile": True
+            "enable_compile": True,
+            "sampler": {
+                "type": "uniform",
+                "kwargs": {
+                    "oversample_factor": 4,
+                    "min_candidate_windows": 128,
+                    "temperature": 1.0,
+                },
+            },
         }
         
         # SLM (Small Language Model) configuration - optimized for 2x A30 GPUs (24GB each)
@@ -181,7 +189,15 @@ class Config:
             "n_positions": 512,  # Full context window
             "vocab_size": 30000,  # Match tokenizer vocabulary size
             # WandB configuration
-            "use_wandb": True  # Set to True to enable WandB logging
+            "use_wandb": True,  # Set to True to enable WandB logging
+            "sampler": {
+                "type": "uniform",
+                "kwargs": {
+                    "oversample_factor": 4,
+                    "min_candidate_windows": 128,
+                    "temperature": 1.0,
+                },
+            },
         }
         
         # Historical Tokenizer configuration (optimized for 1500-1850 English)


### PR DESCRIPTION
## Summary
- add a helper that returns the registered sampler names so the CLI always reflects the current registry
- extend both training entrypoints with a `--list_samplers` flag that prints the available options and exits cleanly
- update the training guide to document the discovery flag for confirming compatibility with the checked-out main branch

## Testing
- python -m compileall 04_training/train_model_slm.py 04_training/train_model.py 04_training/batch_samplers.py

------
https://chatgpt.com/codex/tasks/task_e_68d55febaef48327abf1e5a804dab75a